### PR TITLE
Add functionality to provide file streams and zip them on the fly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'dist/**'
+  push:
+    paths-ignore:
+      - 'dist/**'
+
+jobs:
+  tests:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version:
+        - '3.6'
+        - '3.7'
+        - '3.8'
+        - '3.9'
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Upgrade packaging tools
+      run: python -m pip install --upgrade pip setuptools virtualenv wheel
+
+    - name: Run tests for ${{ matrix.python-version }}
+      run: python -m unittest

--- a/zipfly/test.py
+++ b/zipfly/test.py
@@ -64,6 +64,30 @@ for dirpath, dnames, fnames in os.walk(p3):
             }
         )
 
+class TestBufferInput(unittest.TestCase):
+    def test_buffer_input(self):
+        for test_n in range(1, 2):
+            assert paths1, 'Test does not work without sample files. Change dir and run tests again.'
+
+
+            def buffer_path_generator():
+                for path in paths1:
+                    with open(path['fs'], 'rb') as file:
+                        yield {
+                            'b': file,
+                            'n': '/testcontent' + path['n']
+                        }
+
+            zfly = zipfly.ZipFly(paths=buffer_path_generator())
+            zfly.generator()
+
+            with open("buffer-test{}.zip".format(test_n), "wb") as f:
+                for i in zfly.generator():
+                    f.write(i)
+
+            # Cleanup if test was successful
+            os.remove("buffer-test{}.zip".format(test_n))
+
 class TestBufferPredictionSize(unittest.TestCase):
 
     def test_buffer_prediction_size(self):

--- a/zipfly/test.py
+++ b/zipfly/test.py
@@ -81,9 +81,8 @@ class TestBufferPredictionSize(unittest.TestCase):
 
                 storesize = 0
                 for path in paths1:
-                    f = open(path['fs'], 'rb')
-                    storesize += os.fstat(f.fileno()).st_size
-                    f.close()
+                    with open(path['fs'], 'rb') as f:
+                        storesize += os.fstat(f.fileno()).st_size
 
                 zfly = zipfly.ZipFly( paths = paths1, storesize = storesize )
 
@@ -110,6 +109,9 @@ class TestBufferPredictionSize(unittest.TestCase):
                 )
 
                 self.assertEqual(zs,ps)
+
+                # Cleanup if test was successful
+                os.remove("test{}.zip".format(test_n))
 
 
 if __name__ == '__main__':

--- a/zipfly/zipfly.py
+++ b/zipfly/zipfly.py
@@ -4,6 +4,7 @@ __version__ = '6.0.4'
 
 import io
 import stat
+import time
 import zipfile
 
 ZIP64_LIMIT = (1 << 31) + 1
@@ -56,7 +57,9 @@ class ZipFly:
                  storesize = 0,
                  filesystem = 'fs',
                  arcname = 'n',
-                 encode = 'utf-8',):
+                 encode = 'utf-8',
+                 buffer = 'b',
+                 date_time = 'dt',):
 
         """
         @param store size : int : size of all files
@@ -81,6 +84,8 @@ class ZipFly:
         self.mode = mode
         self.paths = paths
         self.filesystem = filesystem
+        self.buffer = buffer
+        self.date_time = date_time
         self.arcname = arcname
         self.compression = compression
         self.chunksize = chunksize
@@ -151,6 +156,9 @@ class ZipFly:
             '传' has 3 bytes in utf-8 format ( b'\xe4\xbc\xa0' )
             '''
 
+            if self.buffer in self.paths[idx]:
+                raise RuntimeError(f"Buffer prediction does not work if a path contains the key '{self.buffers}' ")
+
             #path = paths[idx]
             name = self.arcname
             if not self.arcname in self.paths[idx]:
@@ -198,61 +206,89 @@ class ZipFly:
 
             for path in self.paths:
 
-                if not self.filesystem in path:
+                if not self.filesystem in path and not self.buffer in path:
 
                     raise RuntimeError(
-                        f" '{self.filesystem}' key is required "
+                        f" '{self.filesystem}' or '{self.buffer}' key is required "
+                    )
+
+                if self.filesystem in path and self.buffer in path:
+
+                    raise RuntimeError(
+                        f"Only on of '{self.filesystem}' or '{self.buffer}' may be provided "
+                    )
+
+                if self.filesystem in path and self.date_time in path:
+                    raise RuntimeError(
+                        f"'{self.date_time}' may only be provided together with '{self.buffer}' "
                     )
 
                 """
                 filesystem should be the path to a file or directory on the filesystem.
+                buffer is a filestream, e.g. the return value of `open('filepath', 'rb')`, and may be used instead of filesystem
                 arcname is the name which it will have within the archive (by default,
                 this will be the same as filename
                 """
 
                 if not self.arcname in path:
 
+                    if self.filesystem not in path:
+                        raise RuntimeError(
+                            f"For a buffer '{self.arcname}' is required "
+                        )
+
                     # arcname will be default path
                     path[self.arcname] = path[self.filesystem]
 
-                z_info = zipfile.ZipInfo.from_file(
-                    path[self.filesystem],
-                    path[self.arcname]
-                )
+                if self.filesystem in path:
+                    z_info = zipfile.ZipInfo.from_file(
+                        path[self.filesystem],
+                        path[self.arcname]
+                    )
 
-                with open( path[self.filesystem], 'rb' ) as e:
-                    # Read from filesystem:
+                    with open( path[self.filesystem], 'rb' ) as e:
+                        # Read from filesystem:
 
-                    with zf.open( z_info, mode = self.mode ) as d:
+                        with zf.open( z_info, mode = self.mode ) as d:
+                            """
+                            buffer = b''
+                            while True:
 
-                        """
-                        buffer = b''
-                        while True:
+                                chunk = e.read(self.chunksize)
+                                if not chunk:
+                                    break
 
-                            chunk = e.read(self.chunksize)
-                            if not chunk:
-                                break
+                                buffer += chunk
+                                elements = buffer.split(b'\0')
 
-                            buffer += chunk
-                            elements = buffer.split(b'\0')
+                                for element in elements[:-1]:
+                                    d.write( element )
+                                    yield stream.get()
 
-                            for element in elements[:-1]:
-                                d.write( element )
+                                buffer = elements[-1]
+
+                            if buffer:
+                                # d.write( buffer )
+                                yield stream.get()
+                            """
+
+                            for chunk in iter( lambda: e.read( self.chunksize ), b'' ):
+
+                                # (e.read( ... )) this get a small chunk of the file
+                                # and return a callback to the next iterator
+
+                                d.write( chunk )
                                 yield stream.get()
 
-                            buffer = elements[-1]
+                else:
+                    if not self.date_time in path:
+                        path[self.date_time] = time.localtime(time.time())[:6]
 
-                        if buffer:
-                            # d.write( buffer )
-                            yield stream.get()
-                        """
-
-                        for chunk in iter( lambda: e.read( self.chunksize ), b'' ):
-
-                            # (e.read( ... )) this get a small chunk of the file
-                            # and return a callback to the next iterator
-
-                            d.write( chunk )
+                    z_info = zipfile.ZipInfo(path[self.arcname], path[self.date_time])
+                    with zf.open(z_info, mode=self.mode) as d:
+                        for chunk in iter(lambda: path[self.buffer].read(self.chunksize),
+                                          b''):
+                            d.write(chunk)
                             yield stream.get()
 
 


### PR DESCRIPTION
It is a common use case to store large files remotely and not next to the code. See e.g. for django https://github.com/jschneier/django-storages. If many (large) files must be shipped synchronuosly as a zip file, it saves memory and storage to pass them through the web worker as a stream without saving anything to disk. To archive that, file buffers as input may be supported.

I would appreciate if we could add this functionality. This pull request contains a tested initial attempt. Feel free to improve!

This pull request is based on https://github.com/BuzonIO/zipfly/pull/75 and https://github.com/BuzonIO/zipfly/pull/76